### PR TITLE
chore: add base README and dbt_project.yml for project setup

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,0 +1,24 @@
+name: ecommerce_data_pipeline_project
+version: 1.0.0
+config-version: 2
+
+profile: user
+
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"
+clean-targets: ["target", "dbt_packages"]
+
+models:
+  ecommerce_data_pipeline_project:
+    staging:
+      +materialized: view
+      +tags: ['staging']
+    marts:
+      +materialized: table
+      +tags: ['marts']


### PR DESCRIPTION
This pull request initializes the dbt project with foundational setup files:

- `README.md` with project overview and documentation structure
- `dbt_project.yml` with configuration for staging and marts folders
- Project name aligned with dbt naming standards (`ecommerce_data_pipeline_project`)
- Tags and materializations applied per folder

No model logic is included in this PR.
