### PR TITLE
feat: add stg_products model with margin logic, validation, and docs

### DIFF
--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -33,3 +33,31 @@ models:
         description: "Number of children currently living at home"
       - name: member_card
         description: "Type of member card held"
+  - name: stg_products
+    description: "Cleaned and validated product data with margin logic and flags"
+    columns:
+      - name: product_id
+        description: "Unique product identifier"
+        tests:
+          - not_null
+          - unique
+      - name: brand
+        description: "Brand name of the product"
+      - name: name
+        description: "Product name"
+      - name: sku
+        description: "Stock keeping unit code"
+      - name: retail_price
+        description: "Retail price of the product"
+      - name: cost
+        description: "Cost of the product"
+      - name: gross_margin_pct
+        description: "Gross margin percentage calculated as (retail - cost) / retail"
+      - name: weight_kg
+        description: "Product weight in kilograms"
+      - name: is_recyclable
+        description: "Whether the product is marked as recyclable"
+      - name: is_low_fat
+        description: "Whether the product is marked as low fat"
+      - name: dq_flag
+        description: "Row-level data quality label, flags invalid margin or weight"

--- a/models/staging/stg_products.sql
+++ b/models/staging/stg_products.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    materialized='view',
+    tags=['staging', 'inventory']
+  )
+}}
+
+SELECT
+  CAST(product_id AS INT64) AS product_id,
+  TRIM(product_brand) AS brand,
+  TRIM(product_name) AS name,
+  CAST(product_sku AS INT64) AS sku,
+  CAST(product_retail_price AS FLOAT64) AS retail_price,
+  CAST(product_cost AS FLOAT64) AS cost,
+  SAFE_DIVIDE(
+    (product_retail_price - product_cost),
+    product_retail_price
+  ) AS gross_margin_pct,
+  CAST(product_weight AS FLOAT64) AS weight_kg,
+  CAST(recyclable AS BOOL) AS is_recyclable,
+  CAST(low_fat AS BOOL) AS is_low_fat,
+  -- Data quality
+  CASE
+    WHEN product_cost > product_retail_price THEN 'NEGATIVE_MARGIN'
+    WHEN product_weight <= 0 THEN 'INVALID_WEIGHT'
+    ELSE 'VALID'
+  END AS dq_flag
+FROM `ecommerce-data-pipeline-465100`.`mavenmarket_raw`.`products`


### PR DESCRIPTION
This pull request adds the staging model for products.

✅ Includes:
- New model: `stg_products.sql`
- Fields: product ID, SKU, name, price, cost, weight
- Logic: 
  - Gross margin percentage calculation
  - Validation via `dq_flag` (flags negative margins or invalid weights)
- Schema tests:
  - not_null and unique on `product_id`
- Column-level descriptions for dbt docs

This model is tagged under the staging and inventory layers and materialized as a view.
