### PR TITLE
feat: add stg_returns model with return validation and documentation

### DIFF
--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -61,3 +61,24 @@ models:
         description: "Whether the product is marked as low fat"
       - name: dq_flag
         description: "Row-level data quality label, flags invalid margin or weight"
+  - name: stg_returns
+    description: "Standardized returns data with parsed date, cleaned fields, and validation"
+    columns:
+      - name: return_date
+        description: "Date of the return (cast as DATE)"
+        tests:
+          - not_null
+      - name: product_id
+        description: "Returned product's unique identifier"
+        tests:
+          - not_null
+      - name: store_id
+        description: "Identifier of the store that processed the return"
+        tests:
+          - not_null
+      - name: return_quantity
+        description: "Number of units returned"
+        tests:
+          - not_null
+      - name: dq_flag
+        description: "Data quality flag; identifies future-dated returns"

--- a/models/staging/stg_returns.sql
+++ b/models/staging/stg_returns.sql
@@ -1,0 +1,18 @@
+{{
+  config(
+    materialized='view',
+    tags=['staging', 'sales']
+  )
+}}
+
+SELECT
+  CAST(return_date AS DATE) AS return_date,
+  CAST(product_id AS INT64) AS product_id,
+  CAST(store_id AS INT64) AS store_id,
+  CAST(quantity AS INT64) AS return_quantity,
+  -- Data quality
+  CASE
+    WHEN return_date > CURRENT_DATE() THEN 'FUTURE_RETURN'
+    ELSE 'VALID'
+  END AS dq_flag
+FROM `ecommerce-data-pipeline-465100`.`mavenmarket_raw`.`returns`


### PR DESCRIPTION
This PR introduces the staging model for returns data:

✅ Changes:
- Created `stg_returns.sql` with cleaned and casted return fields
- Flagged invalid data using `dq_flag` (e.g., future-dated returns)
- Added schema.yml block with:
  - Column descriptions
  - not_null tests for all fields

This model is tagged as staging + sales and materialized as a view.