### PR TITLE
feat: unify transactions_1997 and transactions_1998 in stg_transactions

### DIFF
--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -82,3 +82,22 @@ models:
           - not_null
       - name: dq_flag
         description: "Data quality flag; identifies future-dated returns"
+  - name: stg_transactions
+    description: "Combined 1997 and 1998 transaction data with composite ID and quality filter"
+    columns:
+      - name: transaction_id
+        description: "Synthetic ID using transaction fields; duplicates may exist"
+        tests:
+          - not_null
+      - name: transaction_date
+        description: "Date of transaction"
+      - name: product_id
+        description: "Product involved in transaction"
+      - name: customer_id
+        description: "Customer who transacted"
+      - name: store_id
+        description: "Store where the purchase occurred"
+      - name: quantity
+        description: "Number of items purchased"
+      - name: year
+        description: "Transaction year (1997 or 1998)"

--- a/models/staging/stg_transactions.sql
+++ b/models/staging/stg_transactions.sql
@@ -1,0 +1,46 @@
+{{ config(
+  materialized='view',
+  tags=['staging', 'sales']
+) }}
+
+WITH combined AS (
+  SELECT
+    CAST(transaction_date AS DATE) AS transaction_date,
+    CAST(product_id AS INT64) AS product_id,
+    CAST(customer_id AS INT64) AS customer_id,
+    CAST(store_id AS INT64) AS store_id,
+    CAST(quantity AS INT64) AS quantity,
+    1997 AS year
+  FROM `ecommerce-data-pipeline-465100`.`mavenmarket_raw`.`transactions_1997`
+
+  UNION ALL
+
+  SELECT
+    CAST(transaction_date AS DATE),
+    CAST(product_id AS INT64),
+    CAST(customer_id AS INT64),
+    CAST(store_id AS INT64),
+    CAST(quantity AS INT64),
+    1998 AS year
+  FROM `ecommerce-data-pipeline-465100`.`mavenmarket_raw`.`transactions_1998`
+)
+
+SELECT
+  -- Synthetic unique transaction ID using ROW_NUMBER over all key fields
+  CONCAT(
+    CAST(year AS STRING), '_',
+    CAST(ROW_NUMBER() OVER (
+      PARTITION BY transaction_date, product_id, customer_id, store_id, quantity, year
+      ORDER BY transaction_date
+    ) AS STRING)
+  ) AS transaction_id,
+
+  transaction_date,
+  product_id,
+  customer_id,
+  store_id,
+  quantity,
+  year
+
+FROM combined
+WHERE quantity > 0


### PR DESCRIPTION
This PR introduces the stg_transactions model to consolidate transactional sales data from 1997 and 1998.

✅ Highlights:
- Combines raw datasets `transactions_1997` and `transactions_1998`
- Standardizes date, IDs, and quantity fields
- Adds a synthetic transaction_id using a deterministic row_number strategy
- Filters out invalid rows (quantity ≤ 0)
- Includes column-level documentation and tests for not_null

This model is tagged under staging and sales, and materialized as a view.
