### PR TITLE
feat: add stg_stores model with full store dimension cleanup

### DIFF
--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -101,3 +101,37 @@ models:
         description: "Number of items purchased"
       - name: year
         description: "Transaction year (1997 or 1998)"
+  - name: stg_stores
+    description: "Cleaned and standardized store data including location, structure, and remodel tracking"
+    columns:
+      - name: store_id
+        description: "Unique identifier for each store"
+        tests:
+          - not_null
+          - unique
+      - name: region_id
+        description: "Foreign key to the store's sales region"
+      - name: store_type
+        description: "Type/category of the store"
+      - name: name
+        description: "Store name"
+      - name: street_address
+        description: "Cleaned street address (extra spaces removed)"
+      - name: city
+        description: "City where the store is located"
+      - name: state
+        description: "State or province of the store"
+      - name: country
+        description: "Country of the store"
+      - name: phone
+        description: "Store's contact phone number"
+      - name: opened_date
+        description: "Date when the store was first opened"
+      - name: last_remodel_date
+        description: "Date of the store's last remodel"
+      - name: total_sqft
+        description: "Total area of the store in square feet"
+      - name: grocery_sqft
+        description: "Portion of total area allocated to grocery section"
+      - name: dq_flag
+        description: "Data quality check flag for remodel date logic"

--- a/models/staging/stg_stores.sql
+++ b/models/staging/stg_stores.sql
@@ -1,0 +1,27 @@
+{{
+  config(
+    materialized='view',
+    tags=['staging', 'locations']
+  )
+}}
+
+SELECT
+  CAST(store_id AS INT64) AS store_id,
+  CAST(region_id AS INT64) AS region_id,
+  TRIM(store_type) AS store_type,
+  TRIM(store_name) AS name,
+  REGEXP_REPLACE(TRIM(store_street_address), r'\s{2,}', ' ') AS street_address,
+  TRIM(store_city) AS city,
+  TRIM(store_state) AS state,
+  TRIM(store_country) AS country,
+  TRIM(store_phone) AS phone,
+  CAST(first_opened_date AS DATE) AS opened_date,
+  CAST(last_remodel_date AS DATE) AS last_remodel_date,
+  CAST(total_sqft AS INT64) AS total_sqft,
+  CAST(grocery_sqft AS INT64) AS grocery_sqft,
+  -- Data quality
+  CASE
+    WHEN first_opened_date > last_remodel_date THEN 'INVALID_REMODEL_DATE'
+    ELSE 'VALID'
+  END AS dq_flag
+FROM `ecommerce-data-pipeline-465100`.`mavenmarket_raw`.`stores`


### PR DESCRIPTION
This PR adds the stg_stores staging model to clean and standardize store dimension data.

✅ Includes:
- Field casting and trimming for names, addresses, and contact info
- REGEXP cleaning of street addresses to remove extra spaces
- Remodel logic via `dq_flag` that flags stores where opened_date > last_remodel_date
- Tests:
  - not_null and unique constraint on store_id
- Column-level descriptions for dbt docs

The model is tagged as staging and locations, and materialized as a view.
