### PR TITLE
feat: add stg_regions model for regional mapping and validation

### DIFF
--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -135,3 +135,19 @@ models:
         description: "Portion of total area allocated to grocery section"
       - name: dq_flag
         description: "Data quality check flag for remodel date logic"
+  - name: stg_regions
+    description: "Standardized regional lookup table for store-level sales geography"
+    columns:
+      - name: region_id
+        description: "Unique region identifier used as foreign key to store"
+        tests:
+          - not_null
+          - unique
+      - name: sales_district
+        description: "Specific sales district within the broader region"
+      - name: sales_region
+        description: "High-level regional classification for sales aggregation"
+        tests:
+          - not_null
+      - name: dq_flag
+        description: "Data quality check for missing IDs or region names"

--- a/models/staging/stg_regions.sql
+++ b/models/staging/stg_regions.sql
@@ -1,0 +1,16 @@
+{{ config(
+  materialized='view',
+  tags=['staging', 'locations']
+) }}
+
+SELECT
+  CAST(region_id AS INT64) AS region_id,
+  TRIM(sales_district) AS sales_district,
+  TRIM(sales_region) AS sales_region,
+  -- Data quality checks
+  CASE
+    WHEN region_id IS NULL THEN 'MISSING_REGION_ID'
+    WHEN sales_region IS NULL THEN 'MISSING_SALES_REGION'
+    ELSE 'VALID'
+  END AS dq_flag
+FROM `ecommerce-data-pipeline-465100`.`mavenmarket_raw`.`regions`


### PR DESCRIPTION
This PR adds the stg_regions model, which standardizes regional geography information for stores.

✅ Includes:
- Cleaned region_id, sales_district, and sales_region fields
- Flags invalid records using `dq_flag` for missing region_id or region name
- Column documentation and schema tests (not_null + unique)

This model is tagged as staging and locations, and is materialized as a view.
